### PR TITLE
Personalize site to Eric Riedel

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,11 +1,11 @@
 export default function About() {
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
-      <h1 className="text-4xl font-bold text-gray-900 mb-8">About Me</h1>
+      <h1 className="text-4xl font-bold text-gray-900 mb-8">About Eric Riedel</h1>
       
       <div className="prose prose-lg max-w-none">
         <p className="text-gray-600 mb-6">
-          Welcome to my portfolio! I&apos;m passionate about creating unique and engaging gaming experiences 
+          I am a software product manager and game designer from Seattle, Washington. I&apos;m passionate about creating unique and engaging gaming experiences 
           that challenge conventional thinking and bring people together through interactive design.
         </p>
         

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,8 +15,8 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Game Design Portfolio",
-  description: "A portfolio showcasing creative gaming experiences and design projects",
+  title: "Eric Riedel - Portfolio",
+  description: "Eric Riedel's portfolio showcasing creative gaming experiences and design projects",
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,8 +6,11 @@ export default function Home() {
     <div className="max-w-6xl mx-auto px-4 py-8">
       <section className="text-center mb-12">
         <h1 className="text-4xl font-bold text-gray-900 mb-4">
-          Game Design Portfolio
+          Eric Riedel
         </h1>
+        <p className="text-lg text-gray-600 max-w-2xl mx-auto mb-4">
+          I am a software product manager and game designer from Seattle, Washington
+        </p>
         <p className="text-lg text-gray-600 max-w-2xl mx-auto">
           Welcome to my portfolio of creative gaming experiences, interactive designs, and innovative projects.
         </p>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ export default function Footer() {
     <footer className="bg-gray-50 border-t border-gray-200">
       <div className="max-w-6xl mx-auto px-4 py-6">
         <div className="text-center text-gray-600 text-sm">
-          © 2024 Game Design Portfolio. Built with Next.js.
+          © 2024 Eric Riedel. Built with Next.js.
         </div>
       </div>
     </footer>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -6,7 +6,7 @@ export default function Navigation() {
       <div className="max-w-6xl mx-auto px-4">
         <div className="flex justify-between items-center h-16">
           <Link href="/" className="text-xl font-bold text-gray-900">
-            Portfolio
+            Eric Riedel
           </Link>
           <div className="flex space-x-8">
             <Link href="/" className="text-gray-600 hover:text-gray-900 transition-colors">


### PR DESCRIPTION
## Summary
- Updated site content to use Eric Riedel's name throughout the portfolio
- Added professional summary: "I am a software product manager and game designer from Seattle, Washington"
- Personalized navigation, page titles, metadata, and footer

## Changes Made
- Updated site title and metadata to include Eric Riedel's name
- Modified homepage to prominently display name and professional summary
- Updated About page heading and introduction
- Changed navigation branding from "Portfolio" to "Eric Riedel"
- Updated footer copyright to Eric Riedel

## Test plan
- [x] Verify homepage displays Eric Riedel's name as main heading
- [x] Verify professional summary appears on homepage
- [x] Verify About page uses personalized heading and introduction
- [x] Verify navigation shows "Eric Riedel" instead of "Portfolio"
- [x] Verify footer shows Eric Riedel copyright
- [x] Verify browser tab title shows "Eric Riedel - Portfolio"

🤖 Generated with [Claude Code](https://claude.ai/code)